### PR TITLE
source name in track info

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -382,7 +382,8 @@ Response:
         "isStream": false,
         "position": 0,
         "title": "Rick Astley - Never Gonna Give You Up",
-        "uri": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        "uri": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        "sourceName": "youtube"
       }
     }
   ]

--- a/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.java
+++ b/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.java
@@ -72,7 +72,8 @@ public class AudioLoaderRestHandler {
                 .put("uri", trackInfo.uri)
                 .put("isStream", trackInfo.isStream)
                 .put("isSeekable", audioTrack.isSeekable())
-                .put("position", audioTrack.getPosition());
+                .put("position", audioTrack.getPosition())
+                .put("sourceName", audioTrack.getSourceManager() == null ? null : audioTrack.getSourceManager().getSourceName());
     }
 
     private JSONObject encodeLoadResult(LoadResult result) {


### PR DESCRIPTION
the track source name is already given in the raw track data and should be useful to also have in the `/loadtracks`, `/decodetrack` & `/decodetracks` endpoints